### PR TITLE
support punycode-domains (resolve IP via host)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update && apt-get install -y \
+      bind9-host \
       cron \
       curl \
       git \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,7 +6,7 @@ IP=`curl http://icanhazip.com/`
 trap exit SIGHUP SIGINT SIGTERM
 
 function issue_cert () {
-  if [ "$(ping -c1 -n $1 | head -n1 | sed 's/.*(\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)).*/\1/g')" == "$IP" ]; then
+  if [ "$(host -t A $1|awk '{print $NF}'|head -n1)" == "$IP" ]; then
     acme.sh \
       --home /usr/bin \
       --issue \


### PR DESCRIPTION
Ping from debian-jessie is not able to handle punycode-domains.
Therefore, replaced ping with host.

example: 
https://www.dreikönigs.de --> https://www.xn--dreiknigs-47a.de/